### PR TITLE
Allow env to be configured in AquaCSP CRD 

### DIFF
--- a/deploy/crds/operator_v1alpha1_aquacsp_cr.yaml
+++ b/deploy/crds/operator_v1alpha1_aquacsp_cr.yaml
@@ -64,3 +64,11 @@ spec:
     enforceMode:                            # Optional: true/false if enforcer mode or audit
   route:                                    # Optional: true/false create route to aqua server service, please set server service as NodePort or ClusterIP
   runAsNonRoot:                             # Optional: true/false
+  env:                                      # Optional: if you need to provide custom environment variables
+  - name: "NO_PROXY"                        #           from hardcoded environment variables
+    value: "localhost,.cluster.local"
+  - name: "HTTPS_PROXY"                     #           or from secret
+    valueFrom:
+      secretKeyRef:
+        name: proxy-secret
+        key: HTTPS_PROXY

--- a/deploy/crds/operator_v1alpha1_aquaserver_cr.yaml
+++ b/deploy/crds/operator_v1alpha1_aquaserver_cr.yaml
@@ -27,6 +27,14 @@ spec:
     port:
     username:
     password:                               # Optional: if not using the common.databaseSecret
+  env:                                      # Optional: if you need to provide custom environment variables
+  - name: "NO_PROXY"                        #           - hardcoded environment variables
+    value: "localhost,.cluster.local"
+  - name: "HTTPS_PROXY"                     #           - from secret
+    valueFrom:
+      secretKeyRef:
+        name: proxy-secret
+        key: HTTPS_PROXY
   deploy:                                   # Required: information about aqua server deployment
     replicas: 1                             # Required: number of replicas
     service: "LoadBalancer"                 # Required: service type for aqua server

--- a/pkg/apis/operator/v1alpha1/aquacsp_types.go
+++ b/pkg/apis/operator/v1alpha1/aquacsp_types.go
@@ -1,6 +1,7 @@
 package v1alpha1
 
 import (
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -26,6 +27,7 @@ type AquaCspSpec struct {
 	AdminPassword string                `json:"adminPassword,omitempty"`
 	Enforcer      *AquaEnforcerDetailes `json:"enforcer,omitempty"`
 	Route         bool                  `json:"route,omitempty"`
+	Envs          []corev1.EnvVar       `json:"env,required"`
 	RunAsNonRoot  bool                  `json:"runAsNonRoot,omitempty"`
 }
 

--- a/pkg/controller/aquacsp/cspHelper.go
+++ b/pkg/controller/aquacsp/cspHelper.go
@@ -119,6 +119,7 @@ func (csp *AquaCspHelper) newAquaServer(cr *operatorv1alpha1.AquaCsp) *operatorv
 			AdminPassword:  csp.Parameters.AquaCsp.Spec.AdminPassword,
 			Enforcer:       csp.Parameters.AquaCsp.Spec.Enforcer,
 			RunAsNonRoot:   csp.Parameters.AquaCsp.Spec.RunAsNonRoot,
+			Envs:           csp.Parameters.AquaCsp.Spec.Envs,
 		},
 	}
 


### PR DESCRIPTION
Possible fix for #7 

Seems that the AquaServer CRD already allow to provide **env** from the yaml configuration.
It's just not exposed in the AquaCsp object.

So I add it, and propagate the configuration to the underlying AquaServer object.
