### PR TITLE
Allow to define deployment criterias on Enforcer in CSP

### DIFF
--- a/pkg/apis/operator/v1alpha1/extra_types.go
+++ b/pkg/apis/operator/v1alpha1/extra_types.go
@@ -81,9 +81,13 @@ type AquaScannerCliScale struct {
 }
 
 type AquaEnforcerDetailes struct {
-	Gateway     string `json:"gateway"`
-	Name        string `json:"name"`
-	EnforceMode bool   `json:"enforceMode"`
+	Gateway      string                       `json:"gateway"`
+	Name         string                       `json:"name"`
+	EnforceMode  bool                         `json:"enforceMode"`
+	NodeSelector map[string]string            `json:"nodeSelector,omitempty"`
+	Affinity     *corev1.Affinity             `json:"affinity,omitempty"`
+	Tolerations  []corev1.Toleration          `json:"tolerations,omitempty"`
+	Resources    *corev1.ResourceRequirements `json:"resources,omitempty"`
 }
 
 type AquaDeploymentState string

--- a/pkg/controller/aquacsp/cspHelper.go
+++ b/pkg/controller/aquacsp/cspHelper.go
@@ -169,6 +169,10 @@ func (csp *AquaCspHelper) newAquaEnforcer(cr *operatorv1alpha1.AquaCsp) *operato
 				ImageData: &operatorv1alpha1.AquaImage{
 					Registry: registry,
 				},
+				Affinity:     csp.Parameters.AquaCsp.Spec.Enforcer.Affinity,
+				Tolerations:  csp.Parameters.AquaCsp.Spec.Enforcer.Tolerations,
+				NodeSelector: csp.Parameters.AquaCsp.Spec.Enforcer.NodeSelector,
+				Resources:    csp.Parameters.AquaCsp.Spec.Enforcer.Resources,
 			},
 			RunAsNonRoot: csp.Parameters.AquaCsp.Spec.RunAsNonRoot,
 		},


### PR DESCRIPTION
Allow to define :
- NodeSelector
- Affinity
- Toleration
- Resources (request and limit)

On Enforcer in AquaCSP CRD

Possible fix for #9 