### PR TITLE
Fix operator crash when deploying AquaDatabse CRD.

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+docker run \
+        --rm \
+        -w "/go/src/github.org/aquasecurity/aqua-operator" \
+        -v `pwd`:/go/src/github.org/aquasecurity/aqua-operator \
+        -v //var/run/docker.sock:/var/run/docker.sock \
+        --privileged \
+        aquasec/operator-sdk:latest \
+        operator-sdk build $@

--- a/pkg/apis/operator/v1alpha1/aquacsp_types.go
+++ b/pkg/apis/operator/v1alpha1/aquacsp_types.go
@@ -19,7 +19,7 @@ type AquaCspSpec struct {
 	RegistryData *AquaDockerRegistry      `json:"registry,omitempty"`
 	ExternalDb   *AquaDatabaseInformation `json:"externalDb,omitempty"`
 
-	DbService      *AquaService `jsxon:"database,omitempty"`
+	DbService      *AquaService `json:"database,omitempty"`
 	GatewayService *AquaService `json:"gateway,required"`
 	ServerService  *AquaService `json:"server,required"`
 

--- a/tools/Dockerfile
+++ b/tools/Dockerfile
@@ -1,0 +1,29 @@
+FROM golang:1.13.6-alpine3.10
+
+RUN apk update \
+    && apk upgrade \
+    && apk add --no-cache bash curl git openssh make mercurial openrc docker
+
+# curl for docker image
+# git, mercurial, docker for Operator SDK
+# bash, openssh, make, openrc for QoL
+
+ARG RELEASE_VERSION=v0.15.1
+ARG KUBECTL_VERSION=v1.15.0
+
+# Install Operator SDK
+RUN curl -OJL https://github.com/operator-framework/operator-sdk/releases/download/${RELEASE_VERSION}/operator-sdk-${RELEASE_VERSION}-x86_64-linux-gnu \
+    && chmod +x operator-sdk-${RELEASE_VERSION}-x86_64-linux-gnu \
+    && cp operator-sdk-${RELEASE_VERSION}-x86_64-linux-gnu /usr/local/bin/operator-sdk \
+    && rm operator-sdk-${RELEASE_VERSION}-x86_64-linux-gnu
+
+# Operator SDK says it needs Kubectl, not yet sure why though
+RUN curl -LO https://storage.googleapis.com/kubernetes-release/release/${KUBECTL_VERSION}/bin/linux/amd64/kubectl \
+    && chmod +x ./kubectl \
+    && mv ./kubectl /usr/local/bin/kubectl
+
+# From Operator SDK docs
+ENV GO111MODULE=on
+
+# Need /sys/fs/cgroup to not be read-only, when using Docker
+VOLUME [ "/sys/fs/cgroup", "/go/src" ]


### PR DESCRIPTION
MODIFY: avoid nil pointer dereference when "common" object is not provided in CRD YAML file.