### PR TITLE
Add option to Upgrade Aqua versions using the operator.

### DIFF
--- a/deploy/crds/operator_v1alpha1_aquacsp_cr.yaml
+++ b/deploy/crds/operator_v1alpha1_aquacsp_cr.yaml
@@ -65,4 +65,5 @@ spec:
   route:                                    # Optional: true/false create route to aqua server service, please set server service as NodePort or ClusterIP
   runAsNonRoot:                             # Optional: true/false
   kubeEnforcer:                             # Optional: Install also KubeEnforcer
-    tag:                                    # Optional: KubeEnforcer image tag to install
+    tag:                                    # Optional: KubeEnforcer image tag
+    registry:                               # Optional: KubeEnforcer registry

--- a/pkg/apis/operator/v1alpha1/extra_types.go
+++ b/pkg/apis/operator/v1alpha1/extra_types.go
@@ -110,4 +110,5 @@ type AquaKubeEnforcerConfig struct {
 
 type AquaKubeEnforcerDetails struct {
 	ImageTag string `json:"tag,omitempty"`
+	Registry string `json:"registry,omitempty"`
 }

--- a/pkg/consts/consts.go
+++ b/pkg/consts/consts.go
@@ -56,7 +56,7 @@ const (
 	LatestVersion = "5.3"
 
 	// CyberCenterAddress Aqua Cybercenter Address
-	CyberCenterAddress = "https://cybercenter.aquasec.com"
+	CyberCenterAddress = "https://cybercenter5.aquasec.com"
 
 	// Deployments
 

--- a/pkg/controller/aquacsp/aquacsp_controller.go
+++ b/pkg/controller/aquacsp/aquacsp_controller.go
@@ -529,6 +529,20 @@ func (r *ReconcileAquaCsp) InstallAquaGateway(cr *operatorv1alpha1.AquaCsp) (rec
 			// Spec updated - return and requeue
 			return reconcile.Result{Requeue: true, RequeueAfter: time.Duration(0)}, nil
 		}
+
+		update := !reflect.DeepEqual(aquagw.Spec, found.Spec)
+
+		reqLogger.Info("Checking for AquaGateway Upgrade", "aquagw", aquagw.Spec, "found", found.Spec, "update bool", update)
+		if update {
+			found.Spec = *(aquagw.Spec.DeepCopy())
+			err = r.client.Update(context.Background(), found)
+			if err != nil {
+				reqLogger.Error(err, "Aqua CSP: Failed to update AquaGateway.", "Deployment.Namespace", found.Namespace, "Deployment.Name", found.Name)
+				return reconcile.Result{}, err
+			}
+			// Spec updated - return and requeue
+			return reconcile.Result{Requeue: true}, nil
+		}
 	}
 
 	// AquaGateway already exists - don't requeue
@@ -575,6 +589,20 @@ func (r *ReconcileAquaCsp) InstallAquaServer(cr *operatorv1alpha1.AquaCsp) (reco
 			}
 			// Spec updated - return and requeue
 			return reconcile.Result{Requeue: true, RequeueAfter: time.Duration(0)}, nil
+		}
+
+		update := !reflect.DeepEqual(aquasr.Spec, found.Spec)
+
+		reqLogger.Info("Checking for AquaServer Upgrade", "aquasr", aquasr.Spec, "found", found.Spec, "update bool", update)
+		if update {
+			found.Spec = *(aquasr.Spec.DeepCopy())
+			err = r.client.Update(context.Background(), found)
+			if err != nil {
+				reqLogger.Error(err, "Aqua CSP: Failed to update AquaServer.", "Deployment.Namespace", found.Namespace, "Deployment.Name", found.Name)
+				return reconcile.Result{}, err
+			}
+			// Spec updated - return and requeue
+			return reconcile.Result{Requeue: true}, nil
 		}
 	}
 
@@ -658,6 +686,23 @@ func (r *ReconcileAquaCsp) InstallAquaEnforcer(cr *operatorv1alpha1.AquaCsp) (re
 		return reconcile.Result{Requeue: true, RequeueAfter: time.Duration(0)}, err
 	}
 	// AquaEnforcer already exists - don't requeue
+
+	if found != nil {
+		update := !reflect.DeepEqual(enforcer.Spec, found.Spec)
+
+		reqLogger.Info("Checking for AquaEnforcer Upgrade", "enforcer", enforcer.Spec, "found", found.Spec, "update bool", update)
+		if update {
+			found.Spec = *(enforcer.Spec.DeepCopy())
+			err = r.client.Update(context.Background(), found)
+			if err != nil {
+				reqLogger.Error(err, "Aqua CSP: Failed to update AquaEnforcer.", "Deployment.Namespace", found.Namespace, "Deployment.Name", found.Name)
+				return reconcile.Result{}, err
+			}
+			// Spec updated - return and requeue
+			return reconcile.Result{Requeue: true}, nil
+		}
+	}
+
 	reqLogger.Info("Skip reconcile: Aqua Enforcer Exists", "AquaEnforcer.Namespace", found.Namespace, "AquaEnforcer.Name", found.Name)
 	return reconcile.Result{Requeue: true, RequeueAfter: time.Duration(0)}, nil
 }
@@ -690,6 +735,23 @@ func (r *ReconcileAquaCsp) InstallAquaKubeEnforcer(cr *operatorv1alpha1.AquaCsp)
 		return reconcile.Result{Requeue: true, RequeueAfter: time.Duration(0)}, err
 	}
 	// AquaEnforcer already exists - don't requeue
+
+	if found != nil {
+		update := !reflect.DeepEqual(enforcer.Spec, found.Spec)
+
+		reqLogger.Info("Checking for AquaKubeEnforcer Upgrade", "kube-enforcer", enforcer.Spec, "found", found.Spec, "update bool", update)
+		if update {
+			found.Spec = *(enforcer.Spec.DeepCopy())
+			err = r.client.Update(context.Background(), found)
+			if err != nil {
+				reqLogger.Error(err, "Aqua CSP: Failed to update AquaKubeEnforcer.", "Deployment.Namespace", found.Namespace, "Deployment.Name", found.Name)
+				return reconcile.Result{}, err
+			}
+			// Spec updated - return and requeue
+			return reconcile.Result{Requeue: true}, nil
+		}
+	}
+
 	reqLogger.Info("Skip reconcile: Aqua KubeEnforcer Exists", "AquaKubeEnforcer.Namespace", found.Namespace, "AquaKubeEnforcer.Name", found.Name)
 	return reconcile.Result{Requeue: true, RequeueAfter: time.Duration(0)}, nil
 }

--- a/pkg/controller/aquacsp/cspHelper.go
+++ b/pkg/controller/aquacsp/cspHelper.go
@@ -184,6 +184,10 @@ func (csp *AquaCspHelper) newAquaKubeEnforcer(cr *operatorv1alpha1.AquaCsp) *ope
 			registry = cr.Spec.RegistryData.URL
 		}
 	}
+	if cr.Spec.DeployKubeEnforcer.Registry != "" {
+		registry = cr.Spec.DeployKubeEnforcer.Registry
+	}
+
 	tag := consts.LatestVersion
 	if cr.Spec.DeployKubeEnforcer.ImageTag != "" {
 		tag = cr.Spec.DeployKubeEnforcer.ImageTag

--- a/pkg/controller/aquascanner/aquascanner_controller.go
+++ b/pkg/controller/aquascanner/aquascanner_controller.go
@@ -185,10 +185,13 @@ func (r *ReconcileAquaScanner) InstallScannerDeployment(cr *operatorv1alpha1.Aqu
 	}
 
 	if found != nil {
+		upgrade := deployment.Spec.Template.Spec.Containers[0].Image != found.Spec.Template.Spec.Containers[0].Image
+		reqLogger.Info("Checking for Aqua Scanner Upgrade", "deployment obj", deployment.Spec.Template.Spec.Containers[0].Image, "found obj", found.Spec.Template.Spec.Containers[0].Image, "upgrade bool", upgrade)
 		size := deployment.Spec.Replicas
-		if *found.Spec.Replicas != *size {
+		if *found.Spec.Replicas != *size || upgrade {
 			found.Spec.Replicas = size
-			err = r.client.Status().Update(context.Background(), found)
+			found.Spec.Template.Spec.Containers[0].Image = deployment.Spec.Template.Spec.Containers[0].Image
+			err = r.client.Update(context.Background(), found)
 			if err != nil {
 				reqLogger.Error(err, "Aqua Scanner: Failed to update Deployment.", "Deployment.Namespace", found.Namespace, "Deployment.Name", found.Name)
 				return reconcile.Result{}, err

--- a/pkg/controller/aquaserver/aquaserver_controller.go
+++ b/pkg/controller/aquaserver/aquaserver_controller.go
@@ -370,10 +370,13 @@ func (r *ReconcileAquaServer) InstallServerDeployment(cr *operatorv1alpha1.AquaS
 	}
 
 	if found != nil {
+		upgrade := deployment.Spec.Template.Spec.Containers[0].Image != found.Spec.Template.Spec.Containers[0].Image
+		reqLogger.Info("Checking for Aqua Server Upgrade", "deployment obj", deployment.Spec.Template.Spec.Containers[0].Image, "found obj", found.Spec.Template.Spec.Containers[0].Image, "upgrade bool", upgrade)
 		size := deployment.Spec.Replicas
-		if *found.Spec.Replicas != *size {
+		if *found.Spec.Replicas != *size || upgrade {
 			found.Spec.Replicas = size
-			err = r.client.Status().Update(context.Background(), found)
+			found.Spec.Template.Spec.Containers[0].Image = deployment.Spec.Template.Spec.Containers[0].Image
+			err = r.client.Update(context.Background(), found)
 			if err != nil {
 				reqLogger.Error(err, "Aqua Server: Failed to update Deployment.", "Deployment.Namespace", found.Namespace, "Deployment.Name", found.Name)
 				return reconcile.Result{}, err


### PR DESCRIPTION
ADD: new option when updating the CR version/image the operator will upgrade the CR to the new Aqua version.

MODIFY: add option to determine the registry when deploying KubeEnfocer using AquaCSP installation