### PR TITLE
Add ".aqua" for KubeEnforcer Gateway address.

### DIFF
--- a/docs/DeployOpenShiftOperator.md
+++ b/docs/DeployOpenShiftOperator.md
@@ -363,9 +363,9 @@ metadata:
   name: aqua
 spec:
   config:
-    gateway_address: "aqua-gateway:8443"      # Required: provide <<AQUA GW IP OR DNS: AQUA GW PORT>>
-    cluster_name: "aqua-secure"               # Required: provide your cluster name
-    imagePullSecret: "aqua-registry"          # Optional: needed in case spec.registry is not defined
+    gateway_address: "aqua-gateway.aqua:8443"      # Required: provide <<AQUA GW IP OR DNS: AQUA GW PORT>>
+    cluster_name: "aqua-secure"                    # Required: provide your cluster name
+    imagePullSecret: "aqua-registry"               # Optional: needed in case spec.registry is not defined
   image:
     registry: "registry.aquasec.com"
     tag: "<<KUBE_ENFORCER_TAG>>"

--- a/pkg/controller/aquacsp/cspHelper.go
+++ b/pkg/controller/aquacsp/cspHelper.go
@@ -217,7 +217,7 @@ func (csp *AquaCspHelper) newAquaKubeEnforcer(cr *operatorv1alpha1.AquaCsp) *ope
 		},
 		Spec: operatorv1alpha1.AquaKubeEnforcerSpec{
 			Config: operatorv1alpha1.AquaKubeEnforcerConfig{
-				GatewayAddress:  fmt.Sprintf("%s:8443", fmt.Sprintf(consts.GatewayServiceName, cr.Name)),
+				GatewayAddress:  fmt.Sprintf("%s.%s:8443", fmt.Sprintf(consts.GatewayServiceName, cr.Name), cr.Namespace),
 				ClusterName:     "aqua-secure",
 				ImagePullSecret: cr.Spec.Common.ImagePullSecret,
 			},


### PR DESCRIPTION
MODIFY: change gateway address when deploying KubeEnforcer from "aqua-gateway:8443" to "aqua-gateway.aqua:8443". this change is necessary for MicroEnforcer injection.