### PR TITLE
fixing scanner example doc

### DIFF
--- a/config/crd/bases/operator.aquasec.com_aquaenforcers.yaml
+++ b/config/crd/bases/operator.aquasec.com_aquaenforcers.yaml
@@ -17,7 +17,7 @@ spec:
   versions:
   - additionalPrinterColumns:
     - description: Replicas Number
-      jsonPath: .spec.deploy.replicas
+      jsonPath: .spec.replicas
       name: Replicas
       type: integer
     - description: Aqua Enforcer Age

--- a/controllers/operator/aquacsp/aquacsp_controller.go
+++ b/controllers/operator/aquacsp/aquacsp_controller.go
@@ -42,7 +42,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-var log = logf.Log.WithValues("controller_aquacsp")
+var log = logf.Log.WithName("controller_aquacsp")
 
 // AquaCspReconciler reconciles a AquaCsp object
 type AquaCspReconciler struct {

--- a/docs/DeployOpenShiftOperator.md
+++ b/docs/DeployOpenShiftOperator.md
@@ -704,12 +704,15 @@ spec:
   infra:
     serviceAccount: aqua-sa
     version: '2022.4'
+  common:
+    imagePullSecret: aqua-registry  
   deploy:
     replicas: 1
     image:
       registry: "registry.aquasec.com"
       repository: "scanner"
       tag: "<<IMAGE TAG>>"
+  runAsNonRoot: false                  # Optional: If defined and set to true, the Operator will create the pods with unprivileged user.  
   login:
     username: "<<YOUR AQUA USER NAME>>"
     password: "<<YOUR AQUA USER PASSWORD>>"

--- a/pkg/utils/extra/extra.go
+++ b/pkg/utils/extra/extra.go
@@ -83,6 +83,8 @@ func GetImageData(repo string, version string, imageData *operatorv1alpha1.AquaI
 		tag = consts.LatestVersion
 	}
 
+	fmt.Printf("pullPolicy: %s, registry: %s, repository: %s tag: %s", pullPolicy, registry, repository, tag)
+
 	return pullPolicy, registry, repository, tag
 }
 


### PR DESCRIPTION
Fixing crds and role name
creating csp log WithName instead of WithValues
fixing:
2022-06-09T09:53:01.427480397Z	DPANIC	odd number of arguments passed as key-value pairs for logging	{"ignored key": "controller_aquacsp"}